### PR TITLE
Add Open Source Apple AppStore Screens Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 
 ## Tools
 
-1. [Deeplink](http://www.deeplink.me)
-2. [SensorTower](https://sensortower.com)
-3. [Appannie](https://www.appannie.com/tours/audience-intelligence)
-4. [BoostYourApp](https://boostyour.app) - ASO Decision Engine that tells you what to change in your next update to rank higher
-5. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
+1. [Appannie](https://www.appannie.com/tours/audience-intelligence)
+2. [Appstore Screenshots Generator](https://github.com/jawwadfirdousi/appstore-screenshots-generator) - Open-source App Store screenshot generator.
+3. [BoostYourApp](https://boostyour.app) - ASO Decision Engine that tells you what to change in your next update to rank higher
+4. [Deeplink](http://www.deeplink.me)
+5. [SensorTower](https://sensortower.com)
+6. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
 ## Books
 
 1. [Hooked: How to Build Habit-Forming Products](http://www.amazon.com/Hooked-How-Build-Habit-Forming-Products/dp/1591847788)


### PR DESCRIPTION
## Summary
Add open-source Apple AppStore Screens Generator to the Tools section in `README.md`.

## Changes
Added a new bullet entry with:
- Name: Appstore Screenshots Generator
- Link: https://github.com/jawwadfirdousi/appstore-screenshots-generator
- Short description of what it does

Also ensured the Tools list is sorted alphabetically by name.