### PR TITLE
Add miTT Store Asset Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 3. [BoostYourApp](https://boostyour.app) - ASO Decision Engine that tells you what to change in your next update to rank higher
 4. [Deeplink](http://www.deeplink.me)
 5. [FreshActors App Store & Play Scrapers](https://apify.com/freshactors) - iOS & Android app data, reviews & ASO keywords.
-6. [SensorTower](https://sensortower.com)
-7. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
+6. [miTT Store Asset Generator](https://mittl-medien.de/pwa-asset-generator) - Free generator for App Store & Play icons plus the Play feature graphic.
+7. [SensorTower](https://sensortower.com)
+8. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
 ## Books
 
 1. [Hooked: How to Build Habit-Forming Products](http://www.amazon.com/Hooked-How-Build-Habit-Forming-Products/dp/1591847788)


### PR DESCRIPTION
Adds **miTT Store Asset Generator** to the Tools list (alphabetical position, between FreshActors and SensorTower).

It's a free, hosted tool with no signup that generates App Store and Play Store app icons and the Play feature graphic from a single uploaded image. The Apple icon is flattened onto the chosen background colour (no alpha channel), so it passes App Store Connect validation. Handy when preparing a store listing.

https://mittl-medien.de/pwa-asset-generator
