### PR TITLE
Add Screenshot Resizer (free browser tool for App Store screenshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 3. [BoostYourApp](https://boostyour.app) - ASO Decision Engine that tells you what to change in your next update to rank higher
 4. [Deeplink](http://www.deeplink.me)
 5. [FreshActors App Store & Play Scrapers](https://apify.com/freshactors) - iOS & Android app data, reviews & ASO keywords.
-6. [SensorTower](https://sensortower.com)
-7. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
+6. [Screenshot Resizer](https://screenshotresizer.com/) - In-browser App Store screenshot resizer with device frames and text, no signup.
+7. [SensorTower](https://sensortower.com)
+8. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
 ## Books
 
 1. [Hooked: How to Build Habit-Forming Products](http://www.amazon.com/Hooked-How-Build-Habit-Forming-Products/dp/1591847788)


### PR DESCRIPTION
Adds Screenshot Resizer to the Tools section, sorted alphabetically before SensorTower. It's a free, in-browser tool that resizes iPhone/iPad screenshots to App Store Connect dimensions, applies device frames, and adds marketing text — no uploads, no signup. Fits alongside the existing screenshot tools (Shotlingo, Appstore Screenshots Generator).

Patrick