### PR TITLE
Add Marteso — indie-focused ASO keyword tracking tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 3. [BoostYourApp](https://boostyour.app) - ASO Decision Engine that tells you what to change in your next update to rank higher
 4. [Deeplink](http://www.deeplink.me)
 5. [FreshActors App Store & Play Scrapers](https://apify.com/freshactors) - iOS & Android app data, reviews & ASO keywords.
-6. [SensorTower](https://sensortower.com)
-7. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
+6. [Marteso](https://marteso.com) - ASO keyword tracking, AI metadata optimization and competitor analysis built for indie iOS developers. Permanent free tier (1 app, 50 keywords), Pro at €18/month.
+7. [SensorTower](https://sensortower.com)
+8. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
 ## Books
 
 1. [Hooked: How to Build Habit-Forming Products](http://www.amazon.com/Hooked-How-Build-Habit-Forming-Products/dp/1591847788)


### PR DESCRIPTION
## What

Adds [Marteso](https://marteso.com) to the Tools section.

## Why it fits

Marteso is an App Store Optimization tool built specifically for indie iOS developers. It covers:

- Keyword tracking and difficulty scoring
- AI-generated App Store metadata (title, subtitle, keyword field)
- Competitor analysis

**Pricing:** permanent free tier (1 app, 50 keywords, no credit card required), Pro at €18/month — positioned for indie developers who can't justify $400+/month for enterprise ASO suites.