### PR TITLE
Add Sonar to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 9. [SensorTower](https://sensortower.com)
 10. [Shots](https://shots.run) - Hosted MCP server for AI coding agents to generate App Store screenshots, app icons, ASO listing copy, and localization. Works with Codex, Claude Code, Cursor, and other MCP clients.
 11. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
+12. [Sonar](https://trysonar.app) - AI-first ASO platform for indie developers: keyword research with difficulty and popularity scores, daily rank tracking, review monitoring, and competitor gap analysis for iOS & Android. REST API, CLI, and [MCP server](https://github.com/trysonar/mcp) included.
 
 ## Books
 


### PR DESCRIPTION
Adds [Sonar](https://trysonar.app) to the Tools section (alphabetical, after Shotlingo).

Sonar is an AI-first ASO platform for indie iOS/Android developers — keyword research with difficulty and popularity scores, daily rank tracking, review monitoring, and competitor gap analysis. It ships a REST API, a CLI ([trysonar/cli](https://github.com/trysonar/cli)), and an MCP server ([trysonar/mcp](https://github.com/trysonar/mcp)) so it works with AI agents out of the box. 7-day free trial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)