### PR TITLE
Add Apple Search Popularity explainer to Articles & Posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 23. [8 Things You Should Do Immediately After Launching Your App](http://info.localytics.com/blog/8-things-you-should-do-immediately-after-launching-your-app)
 24. [ASO – 11 WAYS TO INCREASE YOU APP DOWNLOADS](http://growthhackingpro.com/aso-11-ways-increase-app-downloads/)
 25. [The Complete App Store Optimization Checklist: 2016 Edition](https://sensortower.com/blog/app-store-optimization-checklist)
+26. [Apple Search Popularity Score Explained](https://trysonar.app/blog/apple-search-popularity) - What Apple's Search Popularity score (5-100) actually measures, the formula to estimate daily impressions from it, and how to use it for keyword research.
 
 ## Tools
 


### PR DESCRIPTION
Thanks for merging the Sonar tool entry yesterday!

This adds one article to Articles & Posts: [Apple Search Popularity Score Explained](https://trysonar.app/blog/apple-search-popularity) — a data-backed explainer of Apple's Search Popularity metric (the 5-100 score in Apple Search Ads), including a formula to estimate daily impressions from it. The list doesn't currently cover this metric, and it's become the main volume signal for iOS keyword research.

Full disclosure: it's from our own blog, so feel free to close if you'd rather keep first-party content out of that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)