### PR TITLE
Add ShipShots to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 8. [FreshActors App Store & Play Scrapers](https://apify.com/freshactors) - iOS & Android app data, reviews & ASO keywords.
 9. [Marteso](https://marteso.com) - ASO keyword tracking, AI metadata optimization and competitor analysis built for indie iOS developers. Permanent free tier (1 app, 50 keywords), Pro at €18/month.
 10. [SensorTower](https://sensortower.com)
-11. [Shots](https://shots.run) - Hosted MCP server for AI coding agents to generate App Store screenshots, app icons, ASO listing copy, and localization. Works with Codex, Claude Code, Cursor, and other MCP clients.
-12. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
-13. [Sonar](https://trysonar.app) - AI-first ASO platform for indie developers: keyword research with difficulty and popularity scores, daily rank tracking, review monitoring, and competitor gap analysis for iOS & Android. REST API, CLI, and [MCP server](https://github.com/trysonar/mcp) included.
+11. [ShipShots](https://percymcn.github.io/shipshots/) - Free, no-signup, 100% in-browser App Store screenshot generator; configure once and export exact-dimension PNGs for every required size as a zip.
+12. [Shots](https://shots.run) - Hosted MCP server for AI coding agents to generate App Store screenshots, app icons, ASO listing copy, and localization. Works with Codex, Claude Code, Cursor, and other MCP clients.
+13. [Shotlingo](https://shotlingo.com) - Browser-based App Store screenshot generator with AI translation for 40+ languages and batch export.
+14. [Sonar](https://trysonar.app) - AI-first ASO platform for indie developers: keyword research with difficulty and popularity scores, daily rank tracking, review monitoring, and competitor gap analysis for iOS & Android. REST API, CLI, and [MCP server](https://github.com/trysonar/mcp) included.
 
 ## Books
 


### PR DESCRIPTION
Adds **ShipShots** to the Tools section (alphabetical, between SensorTower and Shots).

[ShipShots](https://percymcn.github.io/shipshots/) is a free, no-signup, 100% in-browser App Store screenshot generator: you configure your screens once and export exact-dimension PNGs for every required App Store size as a zip — nothing is uploaded to a server. It sits naturally alongside the other browser-based screenshot tools already listed (Shots, Shotlingo).

Thanks for maintaining this list!