### PR TITLE
Add Storefront Brief to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ _To contribute, click README.md and then the pencil icon. Make your changes and 
 
 1. [apptamin](http://www.apptamin.com/blog/)
 
+2. [Storefront Brief](https://fortune-insight.onrender.com/shop/) - Weekly App Store policy, pricing, and indie launch intel. Free sample on Telegram.
+
 ## Articles & Posts
 
 1. [42 Mobile A/B Testing Terms You Need to Know](http://blog.optimizely.com/2015/03/05/43-mobile-ab-testing-terms-you-need-to-know/)


### PR DESCRIPTION
Adds [Storefront Brief](https://fortune-insight.onrender.com/shop/), a weekly App Store policy / pricing / indie launch intel brief. Free sample on Telegram. Fits the Blogs section next to existing ASO resources.